### PR TITLE
Update jquery.form-abandonment.js

### DIFF
--- a/jquery.form-abandonment.js
+++ b/jquery.form-abandonment.js
@@ -36,7 +36,7 @@
         // the options via the instance, e.g. this.element
         // and this.options
 
-        if (this.element.tagName.indexOf('form') !== -1){
+        if (this.element.tagName.toLowerCase().indexOf('form') !== -1){
             leftPageWithoutFillingOutAnything(this.element);
             submitEvent(this.element);
         }


### PR DESCRIPTION
In XHTML (or any other XML format), tagName is lowercase. In HTML, tagName is uppercase.
This little modification correct the plugin initiation on HTML documents otherwise plugin can't be loaded.
